### PR TITLE
Add GET /api/operators + Add External Operator Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example `Operand` structure:
 
 ## Service Overview
 
-Currently, there is only one endpoint - `POST /api/validation` which performs validation upon the request body. Ex:
+POST /api/validation
 
 Valid request: 
 ```js
@@ -103,6 +103,14 @@ Corresponding response:
     "zip_code_pattern"
   ]
 }
+```
+
+
+Other notable API Endpoints:
+```
+GET /api/rules
+GET /api/rules/:name
+GET /api/operators
 ```
 
 ### Install & Run
@@ -171,7 +179,7 @@ forever npm start
 
   * Node.js is a great environment for handling requests to databases and external APIs when using async calls with the event loop model. That being said, if we have many calls to external services, we can investigate usage of a circuit breaker such as [hystrix](https://www.npmjs.com/package/hystrixjs) to stop cascading failure.
   * On that note, adding promises to this service would make the code more maintainable as these external calls scale.
-  * If a rule is complex, enlisting the help of a database may be helpful. This service could take validation requests and compare against normalized rules or utilize constraints from a relational database.
+  * If a rule is complex, enlisting the help of a database may be helpful. This service could take validation requests and compare against normalized rules or utilize constraints from a relational database. If the rule structure is rapidly changing and does not require any normalization, then a database like MongoDB would be storing rules (not for validating data integrity for things like transactions though).
 
 2. Scaling the number of rules
   * On the other hand, given that Node.js is single-threaded, parallelism is not straightforward (although concurrency is). This service could be implemented to spawn child processes for various rules. However, applying thousands of rules to one JSON object would bode better in an environment like Golang or even Java for goroutines and multithreading respectively. The service could break down the JSON object and apply various rules in parallel to the different portions of the input JSON.

--- a/api/operators/controllers.js
+++ b/api/operators/controllers.js
@@ -9,7 +9,7 @@ let operators = {
     Returns the length of a string or collection (object/array)
   */
   LENGTH: {
-    name: 'LENGTH',
+    name: 'LENGTHc',
     numParameters: 1,
     apply: function (valueArr) {
       return lodash.size(valueArr[0]);
@@ -88,7 +88,7 @@ let operators = {
   }
 };
 
-const FIVE_MINS_IN_MS = 1000;
+const FIVE_MINS_IN_MS = 300000;
 
 function loadExternalOperators() {
   let externalOperators = ExternalOperators.retrieveExternalOperators();

--- a/api/operators/controllers.js
+++ b/api/operators/controllers.js
@@ -1,6 +1,7 @@
 var handleRouteError = require('../utils').handleRouteError;
 var _ = require('underscore');
 var lodash = require('lodash');
+var ExternalOperators = require('./external-operators');
 
 //Operators is private to this module.
 let operators = {
@@ -8,6 +9,7 @@ let operators = {
     Returns the length of a string or collection (object/array)
   */
   LENGTH: {
+    name: 'LENGTH',
     numParameters: 1,
     apply: function (valueArr) {
       return lodash.size(valueArr[0]);
@@ -17,6 +19,7 @@ let operators = {
     Returns the result of applying an input regular expression against the input.
   */
   REGEX_MATCH: {
+    name: 'REGEX_MATCH',
     numParameters: 2,
     apply: function (valueArr) {
       return new RegExp(valueArr[0]).test(valueArr[1]);
@@ -28,6 +31,7 @@ let operators = {
     As a fallback, it performs a strict equality (===)
   */
   EQUAL_TO: {
+    name: 'EQUAL_TO',
     numParameters: 2,
     apply: function (valueArr) {
       let left = valueArr[0];
@@ -44,6 +48,7 @@ let operators = {
     Performs a greater than check between two numbers.
   */
   GREATER_THAN: {
+    name: 'GREATER_THAN',
     numParameters: 2,
     apply: function (valueArr) {
       return Number(valueArr[0]) > Number(valueArr[1]);
@@ -54,6 +59,7 @@ let operators = {
     Does not semantically continue evaluation once true is found.
   */
   OR: {
+    name: 'OR',
     numParameters: -1,
     apply: function (valueArr) {
       for (let i = 0; i < valueArr.length; i++) {
@@ -69,6 +75,7 @@ let operators = {
     Does not senamtically continue evaluation once false is found.
   */
   AND: {
+    name: 'AND',
     numParameters: -1,
     apply: function (valueArr) {
       for (let i = 0; i < valueArr.length; i++) {
@@ -80,6 +87,17 @@ let operators = {
     }
   }
 };
+
+const FIVE_MINS_IN_MS = 1000;
+
+function loadExternalOperators() {
+  let externalOperators = ExternalOperators.retrieveExternalOperators();
+  _.each(externalOperators, function (operator) {
+    operators[operator.name] = operator;
+  });
+};
+
+setInterval(loadExternalOperators, FIVE_MINS_IN_MS);
 
 /* 
   Get all operators currently insite operator registry
@@ -93,5 +111,13 @@ exports.retrieveOperators = function () {
   Retrieve all operators currently inside the operators registry.
 */
 exports.getOperators = function (req, res) {
-  return res.status(200).json(retrieveOperators());
+  //Convert Functions to Strings
+  let jsonFriendlyResponse = {};
+  _.each(exports.retrieveOperators(), function (o, name) {
+    var resOperator = {};
+    resOperator.numParameters = o.numParameters;
+    resOperator.apply = o.apply.toString().replace(/(\\r)|(\\n)/g,"\n");
+    jsonFriendlyResponse[name] = resOperator;
+  });
+  return res.status(200).json(jsonFriendlyResponse);
 };

--- a/api/operators/external-operators.js
+++ b/api/operators/external-operators.js
@@ -1,0 +1,16 @@
+let externalOperators = {
+  /*
+    Performs a less than check between two numbers.
+  */
+  LESS_THAN: {
+    name: 'LESS_THAN',
+    numParameters: 2,
+    apply: function (valueArr) {
+      return Number(valueArr[0]) < Number(valueArr[1]);
+    }
+  },
+};
+
+exports.retrieveExternalOperators = function () {
+  return externalOperators;
+};

--- a/api/rules/controllers.js
+++ b/api/rules/controllers.js
@@ -68,25 +68,27 @@ exports.getRule = function (req, res) {
   overwrite that rule.
   Req: JSON representing a new rule to add to the rules registry
 */
-// exports.addRule = function (req, res) {
-//   if (!req.body) {
-//     return res.status(400).json({
-//       'message': 'No body provided in request.'
-//     });
-//   }
-//   let rule = req.body;
+/*
+exports.addRule = function (req, res) {
+  if (!req.body) {
+    return res.status(400).json({
+      'message': 'No body provided in request.'
+    });
+  }
+  let rule = req.body;
 
-//   //Validate top level of rule structure
-//   if (_.isString(rule.name) || _.isObject(rule.rule)) {
-//     return res.status(400).json({
-//       'message': 'rule structure invalid'
-//     });
-//   }
+  //Validate top level of rule structure
+  if (_.isString(rule.name) || _.isObject(rule.rule)) {
+    return res.status(400).json({
+      'message': 'rule structure invalid'
+    });
+  }
 
-//   //Add the rule
+  //Add the rule
 
-//   //Still in progress!
-// };
+  //Still in progress!
+};
+*/
 
 /*
   DELETE /rule
@@ -95,95 +97,6 @@ exports.getRule = function (req, res) {
 */
 exports.deleteRule = function (req, res) {
 };
-
-/*
-  Checks if a Operand is a rule (whether top-level or nested)
-  Input: Operand 
-  Output: boolean detailing if the operand is a rule.
-*/
-function isRule(obj) {
-  return _.isObject(obj) && obj.hasOwnProperty('operator') && obj.hasOwnProperty('operands');
-}
-
-/*
-  Evaluates an operand. A operand is a token that is either a rule, value, or field.
-  Input: Operand
-  Output: Boolean value
-
-  This utilizes two stacks, one to keep operands as they are evaluated (similar to polish notation),
-  and another to keep values which are determined from operands. This iterative approach uses less 
-  memory for deeply nested rules as it will not add more frames to the call stack when evaluating
-  different levels of rules.
-*/
-function evaluateRuleIterative (rule, userInput) {
-  let operators = Operator.retrieveOperators();
-  operandStack.push(rule);
-  
-  //Keep evaluating operands while we have them.
-  while (!_.isEmpty(operandStack)) {
-    //Get the current operand
-    let currElement = operandStack.pop();
-
-    //If the current operand is a rule, then push the operator and each of the operands onto the stack.
-    if (currElement.hasOwnProperty('operator') && currElement.hasOwnProperty('operands')) {
-      operandStack.push({
-        operator: currElement.operator,
-        size: currElement.operands.length
-      });
-      currElement.operands.forEach(function (o) {
-        operandStack.push(o);
-      });
-
-    //If the current operand is a value, push the value to the value stack.
-    } else if (currElement.hasOwnProperty('value')) {
-      if (!_.isString(currElement.value)) {
-        throw new Error ('Rule Structure invalid: value is not a string. value=' + currElement.value);
-      }
-      valueStack.push(currElement.value);
-
-    //If the current operand is a field, push the field to the value stack if found.
-    } else if (currElement.hasOwnProperty('field')) {
-      let field = lodash.get(userInput, currElement.field, false);
-      if (field === false) {
-        throw new Error('Field ' + currElement.field + ' not found in user input JSON');
-      }
-      valueStack.push(field);
-
-    //If the current operand is an operator, evaluate the operator against values in the value stack.
-    } else if (currElement.hasOwnProperty('operator')) {
-      if (valueStack.length < currElement.size) {
-        throw new Error('Rule structure invalid: not enough values for operator ' + currElement.operator);
-      }
-      let numParameters = operators[currElement.operator].numParameters;
-
-      // -1 denotes a flexible amount of parameters for the operator (e.g. OR)
-      if (numParameters !== -1 && numParameters !== currElement.size) {
-        throw new Error('Rule structure invalid: number of params !== number of. values=' + currElement.size + ', ' + currElement.operator +'=' + numParameters);
-      }
-      //Pop the desired number of values from value stack.
-      let values = [];
-      for (let i = 0; i < currElement.size; i++) {
-        values.push(valueStack.pop());
-      }
-      //push the result
-      valueStack.push(operators[currElement.operator].apply(values));
-    } else {
-      throw new Error('Rule structure invalid: incorrect operand structure');
-    }
-  }
-
-  //When the operand stack is empty, there should just be a single boolean value of whether or not the rule passed:
-  if (valueStack.length !== 1) {
-    throw new Error('Rule structure invalid: did not reduce down to single boolean value.')
-  }
-
-  let result = valueStack.pop();
-  if (!_.isBoolean(result)) {
-    throw new Error ('Rule validation error: Final value not a boolean. value=' + value);
-  }
-  
-  return result;
-}
 
 /*
   This function applies all rules in the rules registry against the user's input.
@@ -212,4 +125,117 @@ exports.applyRules = function (userInput) {
   } catch (e) {
     throw e;
   }
+};
+
+/*
+  Evaluates an operand. A operand is a token that is either a rule, value, or field.
+  Input: Operand
+  Output: Boolean value
+
+  This utilizes two stacks, one to keep operands as they are evaluated (similar to polish notation),
+  and another to keep values which are determined from operands. This iterative approach uses less 
+  memory for deeply nested rules as it will not add more frames to the call stack when evaluating
+  different levels of rules.
+*/
+function evaluateRuleIterative (rule, userInput) {
+  operandStack.push(rule);
+  
+  //Keep evaluating operands while we have them.
+  while (!_.isEmpty(operandStack)) {
+    //Get the current token
+    let currentToken = operandStack.pop();
+
+    //If the current operand is a rule, then push the operator and each of the operands onto the stack.
+    if (currentToken.hasOwnProperty('operator') && currentToken.hasOwnProperty('operands')) {
+      handleRule(currentToken);
+
+    //If the current operand is a value, push the value to the value stack.
+    } else if (currentToken.hasOwnProperty('value')) {
+      handleValue(currentToken);
+
+    //If the current operand is a field, push the field to the value stack if found.
+    } else if (currentToken.hasOwnProperty('field')) {
+      handleField(currentToken, userInput);
+
+    //If the current operand is an operator, evaluate the operator against values in the value stack.
+    } else if (currentToken.hasOwnProperty('operator')) {
+      handleOperator(currentToken);
+    } else {
+      throw new Error('Rule structure invalid: incorrect operand structure');
+    }
+  }
+
+  //When the operand stack is empty, there should just be a single boolean value of whether or not the rule passed:
+  if (valueStack.length !== 1) {
+    throw new Error('Rule structure invalid: did not reduce down to single boolean value.')
+  }
+
+  let result = valueStack.pop();
+  if (!_.isBoolean(result)) {
+    throw new Error ('Rule validation error: Final value not a boolean. value=' + value);
+  }
+
+  return result;
+};
+
+/*
+  Puts a rule's operator and operands onto the operand stack
+  Input: Rule
+*/
+function handleRule (rule) {
+  operandStack.push({
+    operator: rule.operator,
+    size: rule.operands.length
+  });
+  rule.operands.forEach(function (o) {
+    operandStack.push(o);
+  });
+};
+
+/*
+  Puts a value onto the value stack.
+  Input: Value object
+*/
+function handleValue (value) {
+  if (!_.isString(value.value)) {
+    throw new Error ('Rule Structure invalid: value is not a string. value=' + value.value);
+  }
+  valueStack.push(value.value);
+};
+
+/*
+  Puts a field from userInput onto the value stack.
+  Input: Field object
+*/
+function handleField (field, userInput) {
+  let value = lodash.get(userInput, field.field, false);
+  if (field === false) {
+    throw new Error('Field ' + field.field + ' not found in user input JSON');
+  }
+  valueStack.push(value);
+};
+
+/*
+  Applies an operator on values from the value stack.
+  Pushes the result onto the value stack.
+  Input: Operator object
+*/
+function handleOperator (operator) {
+  let operators = Operator.retrieveOperators();
+  if (valueStack.length < operator.size) {
+    throw new Error('Rule structure invalid: not enough values for operator ' + operator.operator);
+  }
+  let numParameters = operators[operator.operator].numParameters;
+
+  // -1 denotes a flexible amount of parameters for the operator (e.g. OR)
+  if (numParameters !== -1 && numParameters !== operator.size) {
+    throw new Error('Rule structure invalid: number of params !== number of. values=' + operator.size + ', ' + operator.operator +'=' + numParameters);
+  }
+  //Pop the desired number of values from value stack.
+  let values = [];
+  for (let i = 0; i < operator.size; i++) {
+    values.push(valueStack.pop());
+  }
+  //push the result
+  valueStack.push(operators[operator.operator].apply(values));
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,5 +10,6 @@ var Operator = require('../api/operators/controllers');
 router.post('/api/validation', Validation.postValidation);
 router.get('/api/rules', Rule.getRules);
 router.get('/api/rules/:name', Rule.getRule);
+router.get('/api/operators', Operator.getOperators);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,5 @@ var Operator = require('../api/operators/controllers');
 router.post('/api/validation', Validation.postValidation);
 router.get('/api/rules', Rule.getRules);
 router.get('/api/rules/:name', Rule.getRule);
-router.post('/api/rules', Rule.addRule);
 
 module.exports = router;


### PR DESCRIPTION
- I decided to simply load the functions from an external file to get a basic implementation of #3  
- GET /api/operators returns the operators and their functions

If we want to explore this more, I noticed that `Function` has a constructor as such:

```js
var sum = new Function('a', 'b', 'return a+b');
```
We can either accept strings representing a function through HTTP (code injection can be very insecure!) or make a more robust plugin implementation on the server itself. Another consideration is whether or not we want to dynamically load plugins at runtime or require a restart each time.